### PR TITLE
Sync particle system color with mode toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,7 +13,7 @@
     --lekh-text: #111;
     --brutalist-hover-bg: #000000;
     --brutalist-hover-text: #FFFFFF;
-    --particle-color-value: 0x000000;
+    --particle-color-value: #000000;
 }
 
 body.dark {
@@ -30,7 +30,12 @@ body.dark {
     --lekh-text: #eee;
     --brutalist-hover-bg: #FFFFFF;
     --brutalist-hover-text: #000000;
-    --particle-color-value: 0xffffff;
+    --particle-color-value: #ffffff;
+}
+
+/* Smooth theme transitions */
+html, body, header, footer, .content-wrapper, #project-modal .modal-content, #loader, #loader-text, #loader-bar, .brutalist-hover, .pivot-experiment, .lekh-title {
+    transition: background-color 300ms ease, color 300ms ease, border-color 300ms ease;
 }
 
 body { 


### PR DESCRIPTION
Implement smooth theme transitions for UI elements and the Three.js particle system, including particle color changes to white in dark mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-663db519-0692-49a5-9eac-46577d61c6fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-663db519-0692-49a5-9eac-46577d61c6fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

