### PR TITLE
Add Rao AI voice assistant with Flask + Gemini backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,39 @@ stvkchrd.dev/
 ## License
 
 © 2025 Satvik Chaturvedi. All rights reserved.
+
+## Rao AI Voice Assistant Setup
+
+### Frontend
+1. Add `RAO_BACKEND_URL` to `js/config.js`:
+   ```javascript
+   window.env = {
+       SUPABASE_URL: 'https://your-project.supabase.co',
+       SUPABASE_ANON_KEY: 'your-anon-key',
+       RAO_BACKEND_URL: 'https://api.stvkchrd.dev/api/rao'
+   };
+   ```
+2. Open the site and click **Rao AI**. The browser captures microphone speech, sends only the transcript to the backend, and reads the response aloud.
+
+### Backend (Flask + Gemini)
+1. Create and activate a virtual environment:
+   ```bash
+   cd backend
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Configure environment variables (never expose this in frontend):
+   ```bash
+   cp .env.example .env
+   # edit .env and set GEMINI_API_KEY
+   export $(grep -v '^#' .env | xargs)
+   ```
+3. Run the API:
+   ```bash
+   python app.py
+   ```
+4. Production notes:
+   - Keep `GEMINI_API_KEY` server-side only.
+   - Set `ALLOWED_ORIGIN` to your exact site domain (default: `https://stvkchrd.dev`).
+   - Expose `/api/rao` over HTTPS.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+GEMINI_API_KEY=your_google_gemini_api_key
+GEMINI_MODEL=gemini-1.5-flash
+ALLOWED_ORIGIN=https://stvkchrd.dev
+PORT=5000

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,48 @@
+import os
+
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+import google.generativeai as genai
+
+ALLOWED_ORIGIN = os.environ.get('ALLOWED_ORIGIN', 'https://stvkchrd.dev')
+GEMINI_API_KEY = os.environ.get('GEMINI_API_KEY')
+GEMINI_MODEL = os.environ.get('GEMINI_MODEL', 'gemini-1.5-flash')
+
+app = Flask(__name__)
+CORS(app, resources={r"/api/*": {"origins": [ALLOWED_ORIGIN]}})
+
+if not GEMINI_API_KEY:
+    raise RuntimeError('GEMINI_API_KEY environment variable is required')
+
+genai.configure(api_key=GEMINI_API_KEY)
+model = genai.GenerativeModel(GEMINI_MODEL)
+
+
+@app.post('/api/rao')
+def rao_chat():
+    body = request.get_json(silent=True) or {}
+    transcript = (body.get('transcript') or '').strip()
+
+    if not transcript:
+        return jsonify({'error': 'transcript is required'}), 400
+
+    prompt = (
+        'You are Rao, a concise and friendly voice assistant for a personal website. '
+        'Answer conversationally and helpfully. Always end every response with "— Rao out." '\
+        f'\n\nUser said: {transcript}'
+    )
+
+    try:
+        result = model.generate_content(prompt)
+        text = (result.text or '').strip()
+    except Exception:
+        return jsonify({'error': 'Upstream model request failed'}), 502
+
+    if not text.endswith('— Rao out.'):
+        text = f"{text.rstrip('. ')} — Rao out."
+
+    return jsonify({'reply': text})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', '5000')))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.3
+flask-cors==4.0.1
+google-generativeai==0.7.2

--- a/index.html
+++ b/index.html
@@ -60,11 +60,13 @@
                         <li><a href="https://x.com/StvkChrd" target="_blank" rel="noopener" class="brutalist-hover block border-2 border-black p-3 font-bold" title="X (Twitter)">X</a></li>
                         <li><a href="https://www.linkedin.com/in/stvkchrd" target="_blank" rel="noopener" class="brutalist-hover block border-2 border-black p-3 font-bold" title="LinkedIn">in</a></li>
                         <li><a href="mailto:satvikc73@gmail.com" class="brutalist-hover block border-2 border-black p-3 font-bold" title="Mail">@</a></li>
-                                                <li><a href="./blog.html" class="brutalist-hover block border-2 border-black px-4 py-3 font-bold">BLOG</a></li>
+                        <li><a href="./blog.html" class="brutalist-hover block border-2 border-black px-4 py-3 font-bold">BLOG</a></li>
+                        <li><button id="rao-ai-button" class="brutalist-hover block border-2 border-black px-4 py-3 font-bold">Rao AI</button></li>
                         <li><button id="theme-toggle" class="brutalist-hover block border-2 border-black p-3 font-bold">MODE</button></li>
                     </ul>
                 </nav>
             </div>
+            <p id="rao-status" class="text-sm font-semibold" aria-live="polite"></p>
              <p class="pivot-experiment text-2xl md:text-3xl font-extrabold mt-2">Pivot &middot; Experiment &middot; Ship &middot; Scale</p>
         </header>
 
@@ -94,5 +96,6 @@
 
     <!-- Your Custom JavaScript -->
     <script src="js/main.js" defer></script>
+    <script src="js/rao-assistant.js" defer></script>
 </body>
 </html>

--- a/js/config.template.js
+++ b/js/config.template.js
@@ -3,7 +3,8 @@
 
 window.env = {
     SUPABASE_URL: 'your-supabase-url-here',
-    SUPABASE_ANON_KEY: 'your-supabase-anon-key-here'
+    SUPABASE_ANON_KEY: 'your-supabase-anon-key-here',
+    RAO_BACKEND_URL: 'https://api.stvkchrd.dev/api/rao'
 };
 
 // For local development, copy this to config.local.js with real credentials

--- a/js/rao-assistant.js
+++ b/js/rao-assistant.js
@@ -1,0 +1,98 @@
+(function () {
+    const button = document.getElementById('rao-ai-button');
+    const status = document.getElementById('rao-status');
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+
+    if (!button) return;
+
+    const BACKEND_URL = (window.env && window.env.RAO_BACKEND_URL) || 'http://127.0.0.1:5000/api/rao';
+
+    function setStatus(message) {
+        if (status) {
+            status.textContent = message;
+        }
+    }
+
+    function speak(text) {
+        if (!window.speechSynthesis) return;
+        const utterance = new SpeechSynthesisUtterance(text);
+        utterance.lang = 'en-US';
+        window.speechSynthesis.cancel();
+        window.speechSynthesis.speak(utterance);
+    }
+
+    async function fetchRaoReply(transcript) {
+        const response = await fetch(BACKEND_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ transcript })
+        });
+
+        if (!response.ok) {
+            throw new Error('Rao backend request failed.');
+        }
+
+        const data = await response.json();
+        return data.reply;
+    }
+
+    async function handleTranscript(transcript) {
+        setStatus('Rao is thinking...');
+
+        try {
+            const reply = await fetchRaoReply(transcript);
+            setStatus(`Rao: ${reply}`);
+            speak(reply);
+        } catch (error) {
+            const fallback = 'Sorry, I hit a snag. Please try again — Rao out.';
+            setStatus(fallback);
+            speak(fallback);
+            console.error(error);
+        } finally {
+            button.disabled = false;
+            button.textContent = 'Rao AI';
+        }
+    }
+
+    function startListening() {
+        if (!SpeechRecognition) {
+            const unsupported = 'Speech recognition is not supported in this browser.';
+            setStatus(unsupported);
+            return;
+        }
+
+        const recognition = new SpeechRecognition();
+        recognition.lang = 'en-US';
+        recognition.interimResults = false;
+        recognition.maxAlternatives = 1;
+
+        button.disabled = true;
+        button.textContent = 'Listening...';
+        setStatus('Listening...');
+
+        recognition.onresult = function (event) {
+            const transcript = event.results[0][0].transcript.trim();
+            setStatus(`You: ${transcript}`);
+            recognition.stop();
+            handleTranscript(transcript);
+        };
+
+        recognition.onerror = function () {
+            const msg = 'Could not capture audio. Please try again.';
+            setStatus(msg);
+            button.disabled = false;
+            button.textContent = 'Rao AI';
+        };
+
+        recognition.onend = function () {
+            if (button.disabled && button.textContent === 'Listening...') {
+                button.disabled = false;
+                button.textContent = 'Rao AI';
+            }
+        };
+
+        recognition.start();
+    }
+
+    button.addEventListener('click', startListening);
+})();


### PR DESCRIPTION
### Motivation
- Provide a lightweight, conversational voice assistant for the site that captures microphone input in-browser, sends only the transcript to a secure server, and speaks replies back to the user.
- Keep the Gemini API key server-side and restrict CORS to the site domain to avoid leaking credentials in frontend code.

### Description
- Added a `Rao AI` button and live status region to the homepage header and wired a new script into `index.html` (`js/rao-assistant.js`).
- Implemented `js/rao-assistant.js` to use the Web Speech API for microphone capture, send a transcript-only POST to a configurable backend (`RAO_BACKEND_URL`), and play the assistant reply with `speechSynthesis`, always ending replies with “— Rao out.”
- Added a minimal Flask backend at `backend/app.py` that reads `GEMINI_API_KEY` and `ALLOWED_ORIGIN` from environment variables, calls Google Gemini via `google.generativeai`, enforces the `— Rao out.` suffix, and returns JSON; CORS is restricted to the configured domain.
- Added `backend/requirements.txt`, `backend/.env.example`, updated `js/config.template.js` to include `RAO_BACKEND_URL`, and added README setup instructions for frontend and backend deployment.

### Testing
- `python -m py_compile backend/app.py` ran and succeeded to verify the Flask module syntax.
- `node --check js/rao-assistant.js` ran and succeeded to verify the assistant script syntax.
- Ran a local static server with `python -m http.server 8000` and captured a Playwright screenshot for manual visual verification of the UI integration (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e113ec4dc832ca0258dd6ca695e17)